### PR TITLE
[demorunner-docker] update upstream changes

### DIFF
--- a/ipol_demo/modules/demorunner-docker/Rocket.toml
+++ b/ipol_demo/modules/demorunner-docker/Rocket.toml
@@ -6,7 +6,6 @@ exec_workdir_in_docker = "/workdir/exec"
 user_uid_gid = "1000:1000"
 gpus = []
 env_vars = {"IPOL_URL"="https://ipolcore.ipol.im"}
-ssh_key_path = "id_ed25519"
 max_timeout = 600
 limits = {"file"="500MB", "data-form"="500MB"}
 

--- a/ipol_demo/modules/demorunner-docker/start.sh
+++ b/ipol_demo/modules/demorunner-docker/start.sh
@@ -15,7 +15,7 @@ if ! command -v cargo &> /dev/null; then
     exit 1
 fi
 
-cargo install --git https://github.com/ipol-journal/ipol-demorunner.git --rev 7bf38a4cb007ea1113ba6a08f133d3c217a405fa --root . --target-dir target --debug --force --locked
+cargo install --git https://github.com/ipol-journal/ipol-demorunner.git --rev cf4dce8a406580964dbea58a77b0d780b3878656 --root . --target-dir target --debug --force --locked
 
 export ROCKET_PROFILE=ipol-$(hostname)
 bin/ipol-demorunner >logs 2>&1 &

--- a/sysadmin/systemd/limule/ipol-demorunner-docker-gpu.service
+++ b/sysadmin/systemd/limule/ipol-demorunner-docker-gpu.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 ExecStart=/home/ipol/ipolDevel/ipol_demo/modules/demorunner-docker/bin/ipol-demorunner
-ExecStartPre=-/home/ipol/.cargo/bin/cargo install --git https://github.com/ipol-journal/ipol-demorunner.git --rev 7bf38a4cb007ea1113ba6a08f133d3c217a405fa --root . --target-dir target --debug --force --locked
+ExecStartPre=-/home/ipol/.cargo/bin/cargo install --git https://github.com/ipol-journal/ipol-demorunner.git --rev cf4dce8a406580964dbea58a77b0d780b3878656 --root . --target-dir target --debug --force --locked
 TimeoutStartSec=300
 WorkingDirectory=/home/ipol/ipolDevel/ipol_demo/modules/demorunner-docker/
 Environment=ROCKET_PROFILE=ipol-limule-gpu

--- a/sysadmin/systemd/limule/ipol-demorunner-docker.service
+++ b/sysadmin/systemd/limule/ipol-demorunner-docker.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 ExecStart=/home/ipol/ipolDevel/ipol_demo/modules/demorunner-docker/bin/ipol-demorunner
-ExecStartPre=-/home/ipol/.cargo/bin/cargo install --git https://github.com/ipol-journal/ipol-demorunner.git --rev 7bf38a4cb007ea1113ba6a08f133d3c217a405fa --root . --target-dir target --debug --force --locked
+ExecStartPre=-/home/ipol/.cargo/bin/cargo install --git https://github.com/ipol-journal/ipol-demorunner.git --rev cf4dce8a406580964dbea58a77b0d780b3878656 --root . --target-dir target --debug --force --locked
 TimeoutStartSec=300
 WorkingDirectory=/home/ipol/ipolDevel/ipol_demo/modules/demorunner-docker/
 Environment=ROCKET_PROFILE=ipol-limule


### PR DESCRIPTION
* cf4dce8 - fix clippy warnings
* 31b2869 - cargo: update
* f084c8e - config: remove ssh_key_path
* 41e5cf1 - support an optional docker registry for demo images
* c0bcb0c - nix: flake update and cleanup
* ad8de8a - execution: cleanup the code
* 6438ec1 - compilation: use tracing to log info
* 926df82 - cargo update
* bf7cd4a - tests: use tracing-test
* 2eb9dd9 - execution: use tracing to log info
* 413ad8b - compilation: use secrecy for private ssh key
* 9b23cb5 - ci: print build logs