### PR TITLE
[CP/fix] missing code on demoextras file select

### DIFF
--- a/cp2/ControlPanel/static_cp/js/demoExtras.js
+++ b/cp2/ControlPanel/static_cp/js/demoExtras.js
@@ -1,4 +1,11 @@
 $(document).ready(function () {
+    $('#file').on('change', function() {
+        let label = document.querySelector('.file-label');
+        let filename = $(this).prop('files')[0].name;
+        label.textContent = filename;
+        $('#save-btn').prop('disabled', false);
+    })
+
     let form = document.querySelectorAll('#editDemoExtras')[0];
     let input		 = form.querySelector('input[type="file"]'),
         label		 = form.querySelector('label'),


### PR DESCRIPTION
This code was missing, maybe I messed up the commits. Anyhow, demoextras upload should work both ways now, with drag and drop and with file selection by clicking on the label.