### PR TITLE
[CP] demo state change parameter type fix

### DIFF
--- a/cp2/ControlPanel/ControlPanel/view.py
+++ b/cp2/ControlPanel/ControlPanel/view.py
@@ -518,7 +518,7 @@ def edit_demo(request):
     title = request.POST['demoTitle']
     state = request.POST['state']
     demo = {
-        'demo_id': new_demo_id,
+        'demo_id': int(new_demo_id),
         'title': title,
         'state': state
     }


### PR DESCRIPTION
Demo_id type was causing an error when editing a demo. I believe last demoinfo PR type specification changed how it should be passed onto the function.