### PR TITLE
Hotfix/avoid browser cache on vr images

### DIFF
--- a/cp2/ControlPanel/static_cp/js/detailsBlob.js
+++ b/cp2/ControlPanel/static_cp/js/detailsBlob.js
@@ -105,7 +105,8 @@ function update_edit_demo() {
 };
 function vrVisibility (blob) {
     if (blob.vr) {
-        document.getElementById("thumbnail_vr").src = blob.vr;
+        // Vr file modification time query parameter to avoid browser cache
+        document.getElementById("thumbnail_vr").src = `${blob.vr}?${blob.vr_mtime}`;
         document.getElementById("thumbnail_vr").style = "visibility : visible"
     }
     else {

--- a/cp2/ControlPanel/templates/showBlobsDemo.html
+++ b/cp2/ControlPanel/templates/showBlobsDemo.html
@@ -17,7 +17,8 @@
                 <button class="btn-delete" name="{{set.name}}" blobPos="{{key}}">X</button>
                 <a href="detailsBlob?demo_id={{demo_id}}&set={{set.name}}&pos={{key}}">
                     {% if blob.thumbnail %}
-                    <img src="{{blob.thumbnail}}">
+                    <!-- Vr file modification time to avoid browser cache -->
+                    <img src="{{blob.thumbnail}}?{{blob.vr_mtime}}">
                     {% else %}
                     <img src="/cp2/static/images/non_viewable_inputs.png">
                     {% endif %}

--- a/ipol_demo/modules/blobs/blobs.py
+++ b/ipol_demo/modules/blobs/blobs.py
@@ -696,12 +696,18 @@ class Blobs():
         thumbnail_url = '/api/blobs/' + thumb_physical_dir
         blob_url = '/api/blobs/' + blob_physical_dir
 
+        vr_path = os.path.join(vr_physical_dir, blob['hash'] + blob['extension'])
+        vr_mtime = ''
+        if os.path.exists(vr_path):
+            vr_mtime = os.path.getmtime(vr_path)
+
         blob_info = {'id': blob['id'],
                      'title': blob['title'],
                      'blob': os.path.join(blob_url, blob['hash'] + blob['extension']),
                      'format': blob['format'],
                      'credit': blob['credit'],
-                     'pos_set': blob['pos_set']}
+                     'pos_set': blob['pos_set'],
+                     'vr_mtime': vr_mtime}
 
         if self.blob_has_thumbnail(blob['hash']):
             blob_info['thumbnail'] = os.path.join(self.module_dir, thumbnail_url, blob['hash'] + '.jpg')


### PR DESCRIPTION
Added VR files modification time to the response from blobs in order to use it from the client side. This proposed solution should avoid browser cache, fixing a problem where new VRs would not show the latest versions even when correctly uploaded because of the web browser having a cached version with the same name.