### PR TITLE
[clientapp] gallery slider script removal

### DIFF
--- a/ipol_demo/clientApp/demo.html
+++ b/ipol_demo/clientApp/demo.html
@@ -118,7 +118,6 @@
   <script src="js/demo.run.js"></script>
   <script src="js/demo.results.js"></script>
   <script src="js/demo.results.gallery.js"></script>
-  <script src="js/demo.results.gallery-slider.js"></script>
   <script src="js/demo.results.video-gallery.js"></script>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/cropper/3.0.0/cropper.min.js" defer></script>


### PR DESCRIPTION
There was an unused script tag added since long ago but forgot to remove it. It was causing a warning error on the browser console.