### PR TITLE
[clientapp/fix] missing quotation marks for radio parameter value

### DIFF
--- a/ipol_demo/clientApp/js/demo.parameters.types.js
+++ b/ipol_demo/clientApp/js/demo.parameters.types.js
@@ -44,7 +44,7 @@ $.fn.selection_radio = function(param, index) {
   $(this).append('<div id=param-' + param.id + '></div>');
   for (var i = 0; i < keys.length; i++) {
     $('#param-' + param.id).append('<div class="radio-option-' + i + '"></div>')
-    $('#param-' + param.id + " > .radio-option-" + i).append(`<input class=hand type=radio name=${param.id} id=selection_radio_${param.id}_${i} value=${values[i]}>`)
+    $('#param-' + param.id + " > .radio-option-" + i).append(`<input class=hand type=radio name=${param.id} id=selection_radio_${param.id}_${i} value="${values[i]}">`)
     $('#param-' + param.id + " > .radio-option-" + i).append(`<label class=hand for=selection_radio_${param.id}_${i}>${keys[i]}</label>`);
     if (param.default_value == values[i]) $(`#selection_radio_${param.id}_${i}`).prop('checked', true);
   }


### PR DESCRIPTION
Missing quotation marks were causing the value to be wrong on certain string values.