### PR TITLE
[CP/fix] user email sync with demoinfo db

### DIFF
--- a/cp2/ControlPanel/ControlPanel/models.py
+++ b/cp2/ControlPanel/ControlPanel/models.py
@@ -1,8 +1,8 @@
 import logging
 
 from django.conf import settings
-from django.core.exceptions import ValidationError
 from django.contrib.auth.models import User as usera
+from django.core.exceptions import ValidationError
 from django.db.models.signals import post_delete, pre_save
 
 # signals


### PR DESCRIPTION
Since as of now demoinfo returns OK but no information in some cases due to mismatch between CP database and demoinfo database concerning editors I've changed it so if no editor is returned it will asume editors will be added to demoinfo if the email is not in there yet.

It is a small change but wanted to make everyone review instead of just commit it.