### PR TITLE
[clientApp] fix demo descritpion style

### DIFF
--- a/ipol_demo/clientApp/css/reset.css
+++ b/ipol_demo/clientApp/css/reset.css
@@ -16,8 +16,13 @@ body {
   line-height: 1;
 }
 
-ol, ul {
-  list-style: none;
+ol, ul, li {
+  font-size: 14px;
+  line-height: 1.3;
+}
+
+li {
+  list-style-position: inside;
 }
 
 blockquote, q {


### PR DESCRIPTION
Before: https://ipolcore.ipol.im/demo/clientApp/demo.html?id=137
![before](https://github.com/ipol-journal/ipolDevel/assets/60109092/c94ef446-48a4-4db9-975d-54c580e9324a)


Now:
![after](https://github.com/ipol-journal/ipolDevel/assets/60109092/a6207da7-228d-4609-90d9-be49e8496267)
