### PR TITLE
[core] prevent inpainting data to be saved into execution.json

### DIFF
--- a/ipol_demo/modules/core/core/core.py
+++ b/ipol_demo/modules/core/core/core.py
@@ -1332,6 +1332,11 @@ class Core:
             list(map(files.pop, file_keys))
             clientdata["files"] = len(file_keys)
 
+        # Remove possible inpainting data files
+        file_keys = [key for key in files if key.startswith("inpainting_")]
+        list(map(files.pop, file_keys))
+        clientdata["blobs"] = len(file_keys)
+
         execution_json = {}
         execution_json["demo_id"] = demo_id
         execution_json["request"] = clientdata


### PR DESCRIPTION
When saving execution.json some inpainting binary data was being saved, which generated an error on inpainting demos.

This is all due to a different way of receiving params when running a demo with fastapi instead of cherrypy.

The solution was to remove those keys and prevent them from being saved.