### PR TITLE
Fix/demo creation won't add editor if demo already exists

### DIFF
--- a/cp2/ControlPanel/ControlPanel/view.py
+++ b/cp2/ControlPanel/ControlPanel/view.py
@@ -155,17 +155,6 @@ def ajax_add_demo(request):
 
     response = {}
     if demo_status != 201:
-        # response = JsonResponse({"status": "OK"})
-        # response["HX-Trigger"] = json.dumps(
-        #     {
-        #         "show-toast": {
-        #             "level": "error",
-        #             "title": "Error",
-        #             "message": "This demo ID is already taken",
-        #         }
-        #     }
-        # )
-        # return response
         messages.warning(request, "This demo ID is already taken")
         return HttpResponseRedirect(request.META["HTTP_REFERER"])
 

--- a/cp2/ControlPanel/ControlPanel/view.py
+++ b/cp2/ControlPanel/ControlPanel/view.py
@@ -3,6 +3,7 @@ import logging
 import urllib
 from datetime import datetime
 
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import render
@@ -152,6 +153,22 @@ def ajax_add_demo(request):
     settings = {"state": state, "title": title, "demo_id": demo_id, "ddl": "{}"}
     result, demo_status = api_post("/api/demoinfo/demo", method="post", params=settings)
 
+    response = {}
+    if demo_status != 201:
+        # response = JsonResponse({"status": "OK"})
+        # response["HX-Trigger"] = json.dumps(
+        #     {
+        #         "show-toast": {
+        #             "level": "error",
+        #             "title": "Error",
+        #             "message": "This demo ID is already taken",
+        #         }
+        #     }
+        # )
+        # return response
+        messages.warning(request, "This demo ID is already taken")
+        return HttpResponseRedirect(request.META["HTTP_REFERER"])
+
     editor_info, _ = api_post(
         "/api/demoinfo/editor", method="get", params={"email": request.user.email}
     )
@@ -160,12 +177,11 @@ def ajax_add_demo(request):
         f"/api/demoinfo/demos/{demo_id}/editor/{editor_id}", method="post"
     )
 
-    response = {}
-    if demo_status != 201 or editor_status != 201:
+    if editor_status != 201:
         response["status"] = "KO"
         response["message"] = result.get("error")
         return JsonResponse(
-            {"status": "KO", "message": result.get("error")}, status=400
+            {"status": "KO", "message": response["message"]}, status=400
         )
     else:
         response["status"] = "OK"

--- a/cp2/ControlPanel/static_cp/js/Homepage.js
+++ b/cp2/ControlPanel/static_cp/js/Homepage.js
@@ -1,5 +1,6 @@
 let csrftoken = getCookie('csrftoken');
 
+
 $(document).ready(function(){
     $('#show').click(function (event) {
         showModal();

--- a/cp2/ControlPanel/templates/base.html
+++ b/cp2/ControlPanel/templates/base.html
@@ -9,6 +9,8 @@
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.12/jquery-ui.min.js"></script>
     <script type="text/javascript" src="/cp2/static/js/functions.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.3.3/ace.js" type="text/javascript" charset="utf-8"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/all.min.css" integrity="sha512-KfkfwYDsLkIlwQp6LFnl8zNdLGxu9YAA1QvwINks4PhcElQSvqcyVLLD9aMhXd13uQjoXtEKNosOWaZqXgel0g==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" type="text/css" href="/cp2/static/css/reset.css" />
@@ -30,9 +32,11 @@
         {% block header %}{% endblock %}
     </header>
     <section id="content">
-        {% block content %}{% endblock %}
+        {% block content %}
+        {% endblock %}
     </section>
     <div id="snackbar"></div>
+    {% include 'messages.html' %}
 </body>
 
 </html>

--- a/cp2/ControlPanel/templates/messages.html
+++ b/cp2/ControlPanel/templates/messages.html
@@ -1,0 +1,24 @@
+{% if messages %}
+    {% for message in messages %}
+        <script type=text/javascript>
+            let options = {
+                "closeButton": true,
+                "debug": false,
+                "newestOnTop": false,
+                "progressBar": false,
+                "positionClass": "toast-bottom-center",
+                "preventDuplicates": false,
+                "onclick": null,
+                "showDuration": "300",
+                "hideDuration": "1000",
+                "timeOut": "5000",
+                "extendedTimeOut": "1000",
+                "showEasing": "swing",
+                "hideEasing": "linear",
+                "showMethod": "fadeIn",
+                "hideMethod": "fadeOut"
+            }
+            toastr.warning('{{ message }}', '', options)
+        </script>
+    {% endfor %}
+{% endif %}

--- a/docker/zsh_conf
+++ b/docker/zsh_conf
@@ -21,7 +21,7 @@ alias cp2devel="cd ~/ipolDevel/cp2 && source venv/bin/activate && python Control
 alias venvcp2="cd ~/ipolDevel/cp2 && source bin/activate"
 
 # Collect all static files from CP.
-alias collectstatic="cd ~/ipolDevel/cp2 && source venv/bin/activate && python manage.py collectstatic --noinput --clear"
+alias collectstatic="cd ~/ipolDevel/cp2/ControlPanel && source ../venv/bin/activate && python manage.py collectstatic --noinput --clear"
 
 # Test all
 alias runtest="cd ~/ipolDevel/ci_tests && python3 all.py"

--- a/ipol_demo/modules/core/demoinfo/router.py
+++ b/ipol_demo/modules/core/demoinfo/router.py
@@ -134,10 +134,12 @@ def read_demo_metainfo(demo_id: int):
 @demoinfoRouter.post("/demo", dependencies=[Depends(validate_ip)], status_code=201)
 def add_demo(demo_id: int, title: str, state: str, ddl: str = None) -> dict:
     result = demoinfo.add_demo(demo_id, title, state, ddl)
+    print(result)
     if isinstance(result, Ok):
         data = {"demo_id": result.value}
     else:
         data = {"error": result.value}
+        raise HTTPException(status_code=409, detail=data)
     return data
 
 

--- a/ipol_demo/modules/core/demoinfo/router.py
+++ b/ipol_demo/modules/core/demoinfo/router.py
@@ -134,7 +134,6 @@ def read_demo_metainfo(demo_id: int):
 @demoinfoRouter.post("/demo", dependencies=[Depends(validate_ip)], status_code=201)
 def add_demo(demo_id: int, title: str, state: str, ddl: str = None) -> dict:
     result = demoinfo.add_demo(demo_id, title, state, ddl)
-    print(result)
     if isinstance(result, Ok):
         data = {"demo_id": result.value}
     else:


### PR DESCRIPTION
Creating a demo with an ID which already existed would add you as an editor to that existing demo. This will prevent that and adds toast messages to inform about the error and will allow for future error notifications.

Minor docker container alias fix added for CP collectstatic