### PR TITLE
Refactor/date is already a datetime object

### DIFF
--- a/ipol_demo/modules/core/archive/router.py
+++ b/ipol_demo/modules/core/archive/router.py
@@ -201,7 +201,7 @@ def update_experiment_date(
         SET timestamp = ?
         WHERE id = ?
         """,
-            (datetime.strptime(date, date_format), experiment_id),
+            (date, experiment_id),
         )
 
         conn.commit()

--- a/ipol_demo/modules/core/archive/router.py
+++ b/ipol_demo/modules/core/archive/router.py
@@ -184,7 +184,7 @@ def get_experiment(experiment_id: int) -> Stored_Experiment:
     "/experiment/{experiment_id}", dependencies=[Depends(validate_ip)], status_code=200
 )
 def update_experiment_date(
-    experiment_id: int, date: datetime, date_format: str
+    experiment_id: int, date: datetime
 ) -> dict[str, int]:
     """
     MIGRATION

--- a/ipol_demo/modules/core/archive/router.py
+++ b/ipol_demo/modules/core/archive/router.py
@@ -183,9 +183,7 @@ def get_experiment(experiment_id: int) -> Stored_Experiment:
 @archiveRouter.put(
     "/experiment/{experiment_id}", dependencies=[Depends(validate_ip)], status_code=200
 )
-def update_experiment_date(
-    experiment_id: int, date: datetime
-) -> dict[str, int]:
+def update_experiment_date(experiment_id: int, date: datetime) -> dict[str, int]:
     """
     MIGRATION
     Update the date of an experiment.


### PR DESCRIPTION
Error while porting demo archive:

```
strptime first argument should be str and not datetime.datetime
Error: update date response {'detail': 'Failed to update the date of experiment #strptime() argument 1 must be str, not datetime.datetime: 2014-03-24 16:29:00'}
```