### PR TITLE
[CP2] navbar user style fix

### DIFF
--- a/cp2/ControlPanel/static_cp/css/header.css
+++ b/cp2/ControlPanel/static_cp/css/header.css
@@ -87,6 +87,8 @@ body#DemoList header {
     position: absolute;
     overflow: auto;
     box-shadow: #63636333 0px 15px 25px 0px;
+    backdrop-filter: blur(1rem);
+    border-radius: 1rem;
 }
 
 .dropdown > button {
@@ -94,6 +96,7 @@ body#DemoList header {
     font-weight: var(--fw-medium);
     border: 0;
     background: none;
+    padding-block: 1rem;
 }
 
 .dropdown:hover .dropdown-content {


### PR DESCRIPTION
Quick fix for user menu background and spacing.

Before:
<img width="219" alt="image" src="https://github.com/user-attachments/assets/c17d72e0-d923-46a6-be6f-3353b350d6e9">


After:
<img width="301" alt="image" src="https://github.com/user-attachments/assets/e9497e47-67cf-4e30-a371-a415310c0226">
