### PR TITLE
docker dr: update to ee2039a8980d199e15cb4f59970c63c335d8c743

### DIFF
--- a/ipol_demo/modules/demorunner-docker/start.sh
+++ b/ipol_demo/modules/demorunner-docker/start.sh
@@ -15,7 +15,7 @@ if ! command -v cargo &> /dev/null; then
     exit 1
 fi
 
-cargo install --git https://github.com/ipol-journal/ipol-demorunner.git --rev cf4dce8a406580964dbea58a77b0d780b3878656 --root . --target-dir target --debug --force --locked
+cargo install --git https://github.com/ipol-journal/ipol-demorunner.git --rev ee2039a8980d199e15cb4f59970c63c335d8c743 --root . --target-dir target --debug --force --locked
 
 export ROCKET_PROFILE=ipol-$(hostname)
 bin/ipol-demorunner >logs 2>&1 &

--- a/sysadmin/systemd/integration/ipol-demorunner-docker.service
+++ b/sysadmin/systemd/integration/ipol-demorunner-docker.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 ExecStart=/home/integration/ipolDevel/ipol_demo/modules/demorunner-docker/bin/ipol-demorunner
-ExecStartPre=-/home/integration/.cargo/bin/cargo install --git https://github.com/ipol-journal/ipol-demorunner.git --rev e920d05b63ba5dc7da9700f05e6b89e6a993738c --root . --target-dir target --debug --force --locked
+ExecStartPre=-/home/integration/.cargo/bin/cargo install --git https://github.com/ipol-journal/ipol-demorunner.git --rev ee2039a8980d199e15cb4f59970c63c335d8c743 --root . --target-dir target --debug --force --locked
 TimeoutStartSec=300
 WorkingDirectory=/home/integration/ipolDevel/ipol_demo/modules/demorunner-docker/
 Environment=ROCKET_PROFILE=ipol-integration

--- a/sysadmin/systemd/limule/ipol-demorunner-docker-gpu.service
+++ b/sysadmin/systemd/limule/ipol-demorunner-docker-gpu.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 ExecStart=/home/ipol/ipolDevel/ipol_demo/modules/demorunner-docker/bin/ipol-demorunner
-ExecStartPre=-/home/ipol/.cargo/bin/cargo install --git https://github.com/ipol-journal/ipol-demorunner.git --rev 6fa8ce059c30a4c2eef485050f1c4394ab1cef1d --root . --target-dir target --debug --force --locked
+ExecStartPre=-/home/ipol/.cargo/bin/cargo install --git https://github.com/ipol-journal/ipol-demorunner.git --rev ee2039a8980d199e15cb4f59970c63c335d8c743 --root . --target-dir target --debug --force --locked
 TimeoutStartSec=300
 WorkingDirectory=/home/ipol/ipolDevel/ipol_demo/modules/demorunner-docker/
 Environment=ROCKET_PROFILE=ipol-limule-gpu

--- a/sysadmin/systemd/limule/ipol-demorunner-docker.service
+++ b/sysadmin/systemd/limule/ipol-demorunner-docker.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 ExecStart=/home/ipol/ipolDevel/ipol_demo/modules/demorunner-docker/bin/ipol-demorunner
-ExecStartPre=-/home/ipol/.cargo/bin/cargo install --git https://github.com/ipol-journal/ipol-demorunner.git --rev 6fa8ce059c30a4c2eef485050f1c4394ab1cef1d --root . --target-dir target --debug --force --locked
+ExecStartPre=-/home/ipol/.cargo/bin/cargo install --git https://github.com/ipol-journal/ipol-demorunner.git --rev ee2039a8980d199e15cb4f59970c63c335d8c743 --root . --target-dir target --debug --force --locked
 TimeoutStartSec=300
 WorkingDirectory=/home/ipol/ipolDevel/ipol_demo/modules/demorunner-docker/
 Environment=ROCKET_PROFILE=ipol-limule


### PR DESCRIPTION
see https://github.com/ipol-journal/ipol-demorunner/pull/1

The new version:
- allows by default any fingerprint from the host,
- allows an optional parameter `ssh_fingerprints: list[str]` that the editor can set in the DDL build section to enforce the validation of the host key.